### PR TITLE
Fix error in callback handling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,22 +16,26 @@ const pluginBabel = (options = {}) => ({
 				babelOptions.sourceFileName = filename;
 			}
 
-			babel.transform(contents, babelOptions, (error, result) => {
-				if (error) throw error;
-
-				contents = result.code;
+			return new Promise((resolve, reject) => {
+				babel.transform(contents, babelOptions, (error, result) => {
+					if (error) {
+						reject(error);
+					} else {
+						resolve({ contents: result.code });
+					}
+				});
 			});
-
-			return { contents };
 		};
 
-		if (transform) return transformContents(transform);
+		if (transform) {
+			return transformContents(transform);
+		} else {
+			build.onLoad({ filter, namespace }, async args => {
+				const contents = await fs.promises.readFile(args.path, 'utf8');
 
-		build.onLoad({ filter, namespace }, async args => {
-			const contents = await fs.promises.readFile(args.path, 'utf8');
-
-			return transformContents({ args, contents });
-		});
+				return transformContents({ args, contents });
+			});
+		}
 	}
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const pluginBabel = (options = {}) => ({
 		const { filter = /.*/, namespace = '', config = {} } = options;
 
 		const transformContents = ({ args, contents }) => {
-			const babelOptions = babel.loadOptions(config);
+			const babelOptions = babel.loadOptions({ filename: args.path, ...config });
 
 			if (babelOptions.sourceMaps) {
 				const filename = path.relative(process.cwd(), args.path);


### PR DESCRIPTION
Hey! 

I found that the code handling the babel transformation, which is basically the key of the plugin might be flawed.

In the original code:
```javascript
// snippet from line :19
babel.transform(contents, babelOptions, (error, result) => {
  if (error) throw error;
  contents = result.code;
});

return { contents };
```

This original code would return before the callback would be ever fired, unless the implementation for `babel.transform` does call the callback synchronously, which I believe it's not doing. 

Fixing this locally also unblocked my babel compilation step, so I think it might be a valid fix.

Please check my PR for a suggestion on fixing.