### PR TITLE
pass caller info to babel

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,14 @@ const pluginBabel = (options = {}) => ({
 		const { filter = /.*/, namespace = '', config = {} } = options;
 
 		const transformContents = ({ args, contents }) => {
-			const babelOptions = babel.loadOptions({ filename: args.path, ...config });
+			const babelOptions = babel.loadOptions({
+				...config,
+				filename: args.path,
+				caller: {
+					name: 'esbuild-plugin-babel',
+					supportsStaticESM: true
+				}
+			});
 
 			if (babelOptions.sourceMaps) {
 				const filename = path.relative(process.cwd(), args.path);


### PR DESCRIPTION
https://babeljs.io/docs/en/options#caller
> Utilities may pass a caller object to identify themselves to Babel and pass capability-related flags for use by configs, presets and plugins.

Tell babel that esbuild prefers ESModules rather than commonjs. This enables tree-shaking, etc. The alternative is to add something like this to your babel config:
```
  presets: [
    ['@babel/preset-env', {
        modules: false
    }]
  ]
```

https://babeljs.io/docs/en/babel-preset-env#modules
> Setting this to false will preserve ES modules. Use this only if you intend to ship native ES Modules to browsers. If you are using a bundler with Babel, the default modules: "auto" is always preferred.