### PR TITLE
Return `contents` if `babelOptions` do not exist

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ const pluginBabel = (options = {}) => ({
 					supportsStaticESM: true
 				}
 			});
+			if (!babelOptions) return { contents }
 
 			if (babelOptions.sourceMaps) {
 				const filename = path.relative(process.cwd(), args.path);


### PR DESCRIPTION
When setting `ignore` field in `babel.config.json`, ex:

```json
  "ignore":[
    "node_modules/core-js"
  ]
```

, the `babelOptions` for the ignored files is `null`. This causes a failure when trying to retrieve `babelOptions.sourceMaps`. Ex:

```
 > src/index.ts: error: [babel] Cannot read property 'sourceMaps' of null
    6 │ import "core-js/modules/es.array.join.js";
```

Since the options are `null`, I interpreted that as no transformations should be performed. So I preemptively return the contents before setting up the processing `Promise`.

------------

Other packages installed that might be related to my original error.

```yaml
    "@babel/core": "^7.12.17",
    "@babel/preset-env": "^7.12.17",
    "@babel/preset-typescript": "^7.12.17",
    "@babel/runtime": "^7.12.18",
```