### PR TITLE
Remove module tag. Now interpreted as CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
 	"license": "ISC",
 	"exports": "./src/index.js",
 	"main": "src/index.js",
-	"type": "module",
 	"scripts": {
 		"format": "prettier --write --ignore-unknown '**/*'"
 	},

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const pluginBabel = (options = {}) => ({
 					supportsStaticESM: true
 				}
 			});
-			if (!babelOptions) return { contents };
+			if (!babelOptions) return;
 
 			if (babelOptions.sourceMaps) {
 				const filename = path.relative(process.cwd(), args.path);

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
-import babel from '@babel/core';
-import fs from 'fs';
-import path from 'path';
+const babel = require('@babel/core');
+const fs = require('fs');
+const path = require('path');
 
 const pluginBabel = (options = {}) => ({
 	name: 'babel',
@@ -41,4 +41,4 @@ const pluginBabel = (options = {}) => ({
 	}
 });
 
-export default pluginBabel;
+module.exports = pluginBabel;


### PR DESCRIPTION
Changes:
* The return TypeScript type for `setup()` is `(void | Promise<void>)` (https://github.com/evanw/esbuild/blob/223150f924d746226eedd703d7419dfa636c642f/lib/shared/types.ts#L189). When there are no babel options to parse, it now returns _nothing_.

--------------------------

Changes:
* Use `require()` / `modules.export` to import objects and export the default value
* Remove `"type": "module"` from `package.json` to default back to `"type": "commonjs"`

External Support:
* From https://redfin.engineering/node-modules-at-war-why-commonjs-and-es-modules-cant-get-along-9617135eeca1
> 1. Provide a CJS version of your library
> ...
> If your library only provides a default (unnamed) export, you’re done

Since the plugin is small and only has a `default` export, then we can convert it to a CJS module. Now both CJS and ES modules can require/import this module.

(Motivation by [not being able to import ES modules within `ts-node`](https://github.com/TypeStrong/ts-node/issues/1007).)

