### PR TITLE
[fix] Crash reading excluded files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,9 +34,13 @@ const pluginBabel = (options = {}) => ({
 		if (transform) return transformContents(transform);
 
 		build.onLoad({ filter, namespace }, async args => {
-			const contents = await fs.promises.readFile(args.path, 'utf8');
+			try {
+				const contents = await fs.promises.readFile(args.path, 'utf8');
 
-			return transformContents({ args, contents });
+				return transformContents({ args, contents });
+			} catch {
+				return null;
+			}
 		});
 	}
 });


### PR DESCRIPTION
Ignores readFile error if a file is excluded by e.g. the `browser` field in package.json